### PR TITLE
Immutable repo

### DIFF
--- a/src/main/scala/frdomain/ch5/free/AccountRepoMutable.scala
+++ b/src/main/scala/frdomain/ch5/free/AccountRepoMutable.scala
@@ -1,6 +1,7 @@
 package frdomain.ch5
 package free
 
+import scala.language.higherKinds
 import scala.collection.mutable.{ Map => MMap }
 import scalaz._
 import Scalaz._
@@ -8,20 +9,20 @@ import scalaz.concurrent.Task
 import Task._
 import Free._
 
-trait AccountRepoInterpreter {
-  def apply[A](action: AccountRepo[A]): Task[A]
+trait AccountRepoInterpreter[M[_]] {
+  def apply[A](action: AccountRepo[A]): M[A]
 }
   
 /**
  * Basic interpreter that uses a global mutable Map to store the state
  * of computation
  */
-case class AccountRepoMutableInterpreter() extends AccountRepoInterpreter {
+case class AccountRepoMutableInterpreter() extends AccountRepoInterpreter[Task] {
   val table: MMap[String, Account] = MMap.empty[String, Account]
 
   def step[A](action: AccountRepoF[AccountRepo[A]]): Task[AccountRepo[A]] = action match {
 
-    case Query(no, onResult) => 
+    case Query(no, onResult) =>
       table.get(no).map { a => now(onResult(a)) }
                    .getOrElse { fail(new RuntimeException(s"Account no $no not found")) }
 

--- a/src/main/scala/frdomain/ch5/free/Main.scala
+++ b/src/main/scala/frdomain/ch5/free/Main.scala
@@ -38,5 +38,7 @@ object Main {
     val u = inter.apply(comp)
 
     val v = AccountRepoShowInterpreter().interpret(comp, List.empty[String])
+
+    val st = AccountRepoStateInterpreter(comp).run(Map.empty)
   }
 }


### PR DESCRIPTION
The sample `AccountRepo` made use of a mutable map which leaks outside the method scope and `Task` for effect.

Here's an alternative approach which makes use of immutable maps and a less powerful monad.

Might this be useful? I started out with the free section. I can maybe further edit other parts that makes use of mutable maps if necessary.