### PR TITLE
Eliminate timing-induced failures in AccountService in chapter 3

### DIFF
--- a/src/main/scala/frdomain/ch3/algebra/interpreter/AccountService.scala
+++ b/src/main/scala/frdomain/ch3/algebra/interpreter/AccountService.scala
@@ -9,9 +9,10 @@ import algebra.AccountService
 
 object AccountService extends AccountService[Account, Amount, Balance] {
   def open(no: String, name: String, openingDate: Option[Date]): Try[Account] = {
+    val currentDate = today
     if (no.isEmpty || name.isEmpty) Failure(new Exception(s"Account no or name cannot be blank") )
-    else if (openingDate.getOrElse(today) before today) Failure(new Exception(s"Cannot open account in the past"))
-    else Success(Account(no, name, openingDate.getOrElse(today)))
+    else if (openingDate.getOrElse(currentDate) before currentDate) Failure(new Exception(s"Cannot open account in the past"))
+    else Success(Account(no, name, openingDate.getOrElse(currentDate)))
   }
 
   def close(account: Account, closeDate: Option[Date]): Try[Account] = {

--- a/src/test/scala/frdomain/ch3/algebra/interpreter/AccountServiceSpec.scala
+++ b/src/test/scala/frdomain/ch3/algebra/interpreter/AccountServiceSpec.scala
@@ -1,0 +1,23 @@
+package frdomain.ch3
+package algebra
+package interpreter
+
+import org.scalacheck._
+import Prop.forAll
+
+object AccountServiceSpec extends Properties("AccountService") {
+
+  import AccountService._
+
+  val genValidAccountNo = Gen.choose(100000, 999999).map(_.toString)
+  val genName = Gen.oneOf("john", "david", "mary")
+
+  val validOpenedAccount = for {
+    no <- genValidAccountNo
+    name <- genName
+  } yield open(no, name, None)
+
+  property("open account has no timing issues") =
+    forAll(validOpenedAccount)(_.isSuccess)
+
+}


### PR DESCRIPTION
Due to the use of the today function in several places in the function, the account creation occasionally fails when the generated timestamp differs. 

I added a test to prove this is the case (it sometimes still passes, showing the "randomly failing" nature of the problem)
